### PR TITLE
Improvements for java-side tests

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -90,7 +90,7 @@ jobs:
           key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
           restore-keys: ${{ runner.os }}-maven-
       - name: Build Mondrian JAR
-        run: mvn package -q
+        run: mvn package -q -DskipTests
       - name: Setup Ruby and install gems
         uses: ruby/setup-ruby@v1
         with:
@@ -145,7 +145,7 @@ jobs:
           key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
           restore-keys: ${{ runner.os }}-maven-
       - name: Build Mondrian JAR
-        run: mvn package -q
+        run: mvn package -q -DskipTests
       - name: Setup Ruby and install gems
         uses: ruby/setup-ruby@v1
         with:

--- a/README.md
+++ b/README.md
@@ -18,9 +18,21 @@ A fork of the Mondrian OLAP Java engine, maintained to provide the core Java lib
 2. The output JAR is produced in `mondrian/target/`
 3. After building, the JAR files should be copied to the mondrian-olap gem's `lib/mondrian/jars/` directory
 
-## Testing
+## Testing for mondrian-olap
 
 After making changes, build the JAR, copy it to the mondrian-olap gem, and run the gem's test suite.
+
+## Testing in this repository
+
+    # Run the Ruby tests
+    mise run test
+
+    # Run the original Java test suite
+    mise run test_java
+
+    # Run a single Java test
+    mise run single_java_test NativeFilterMatchingTest
+
 
 ## Fork-Specific Patches
 

--- a/README.md
+++ b/README.md
@@ -25,13 +25,13 @@ After making changes, build the JAR, copy it to the mondrian-olap gem, and run t
 ## Testing in this repository
 
     # Run the Ruby tests
-    mise run test
+    mise test
 
-    # Run the original Java test suite
-    mise run test_java
+    # Run all Java tests
+    mise java_test
 
     # Run a single Java test
-    mise run single_java_test NativeFilterMatchingTest
+    mise java_test NativeFilterMatchingTest
 
 
 ## Fork-Specific Patches

--- a/bin/java_test
+++ b/bin/java_test
@@ -1,0 +1,39 @@
+#!/bin/bash
+set -euo pipefail
+
+DRIVER="${MONDRIAN_DRIVER:-mysql}"
+HOST="${DATABASE_HOST:-localhost}"
+USER="${DATABASE_USER:-foodmart}"
+PASS="${DATABASE_PASSWORD:-foodmart}"
+DB="${DATABASE_NAME:-foodmart}"
+
+case "$DRIVER" in
+  mysql)
+    PORT="${DATABASE_PORT:-3306}"
+    URL="jdbc:mysql://$HOST:$PORT/$DB?useSSL=false&serverTimezone=UTC&allowPublicKeyRetrieval=true"
+    DRIVERS="com.mysql.cj.jdbc.Driver"
+    ;;
+  postgresql)
+    PORT="${DATABASE_PORT:-5432}"
+    URL="jdbc:postgresql://$HOST:$PORT/$DB"
+    DRIVERS="org.postgresql.Driver"
+    ;;
+  *)
+    echo "Unsupported driver: $DRIVER" >&2
+    exit 1
+    ;;
+esac
+
+if [ $# -gt 0 ]; then
+  TEST_NAME="$1"
+  shift
+  mvn test -pl mondrian \
+    -Dtest="$TEST_NAME" \
+    -Dmondrian.foodmart.jdbcURL="$URL" \
+    -Dmondrian.foodmart.jdbcUser="$USER" \
+    -Dmondrian.foodmart.jdbcPassword="$PASS" \
+    -Dmondrian.jdbcDrivers="$DRIVERS" \
+    "$@"
+else
+  mvn -DrunITs install -Djava.locale.providers=COMPAT,SPI
+fi

--- a/mise.toml
+++ b/mise.toml
@@ -14,3 +14,49 @@ run = "mvn -DrunITs install -Djava.locale.providers=COMPAT,SPI"
 description = "Run JRuby Minitest tests"
 run = "rake test"
 depends = ["package"]
+
+[tasks.single_java_test]
+description = "Run a single Java test (e.g., mise run single_java_test NativeFilterMatchingTest)"
+run = """
+#!/bin/bash
+set -euo pipefail
+
+if [ $# -eq 0 ]; then
+  echo "Usage: mise run java_test <TestClassName>" >&2
+  exit 1
+fi
+
+DRIVER="${MONDRIAN_DRIVER:-mysql}"
+HOST="${DATABASE_HOST:-localhost}"
+USER="${DATABASE_USER:-foodmart}"
+PASS="${DATABASE_PASSWORD:-foodmart}"
+DB="${DATABASE_NAME:-foodmart}"
+
+case "$DRIVER" in
+  mysql)
+    PORT="${DATABASE_PORT:-3306}"
+    URL="jdbc:mysql://$HOST:$PORT/$DB?useSSL=false&serverTimezone=UTC&allowPublicKeyRetrieval=true"
+    DRIVERS="com.mysql.cj.jdbc.Driver"
+    ;;
+  postgresql)
+    PORT="${DATABASE_PORT:-5432}"
+    URL="jdbc:postgresql://$HOST:$PORT/$DB"
+    DRIVERS="org.postgresql.Driver"
+    ;;
+  *)
+    echo "Unsupported driver: $DRIVER" >&2
+    exit 1
+    ;;
+esac
+
+TEST_NAME="$1"
+shift
+
+mvn test -pl mondrian \
+  -Dtest="$TEST_NAME" \
+  -Dmondrian.foodmart.jdbcURL="$URL" \
+  -Dmondrian.foodmart.jdbcUser="$USER" \
+  -Dmondrian.foodmart.jdbcPassword="$PASS" \
+  -Dmondrian.jdbcDrivers="$DRIVERS" \
+  "$@"
+"""

--- a/mise.toml
+++ b/mise.toml
@@ -6,57 +6,11 @@ maven = "3.9"
 [tasks.package]
 run = "mvn package"
 
-[tasks.test_java]
-description = "Run integration tests with Docker MySQL"
-run = "mvn -DrunITs install -Djava.locale.providers=COMPAT,SPI"
-
 [tasks.test]
 description = "Run JRuby Minitest tests"
 run = "rake test"
 depends = ["package"]
 
-[tasks.single_java_test]
-description = "Run a single Java test (e.g., mise run single_java_test NativeFilterMatchingTest)"
-run = """
-#!/bin/bash
-set -euo pipefail
-
-if [ $# -eq 0 ]; then
-  echo "Usage: mise run java_test <TestClassName>" >&2
-  exit 1
-fi
-
-DRIVER="${MONDRIAN_DRIVER:-mysql}"
-HOST="${DATABASE_HOST:-localhost}"
-USER="${DATABASE_USER:-foodmart}"
-PASS="${DATABASE_PASSWORD:-foodmart}"
-DB="${DATABASE_NAME:-foodmart}"
-
-case "$DRIVER" in
-  mysql)
-    PORT="${DATABASE_PORT:-3306}"
-    URL="jdbc:mysql://$HOST:$PORT/$DB?useSSL=false&serverTimezone=UTC&allowPublicKeyRetrieval=true"
-    DRIVERS="com.mysql.cj.jdbc.Driver"
-    ;;
-  postgresql)
-    PORT="${DATABASE_PORT:-5432}"
-    URL="jdbc:postgresql://$HOST:$PORT/$DB"
-    DRIVERS="org.postgresql.Driver"
-    ;;
-  *)
-    echo "Unsupported driver: $DRIVER" >&2
-    exit 1
-    ;;
-esac
-
-TEST_NAME="$1"
-shift
-
-mvn test -pl mondrian \
-  -Dtest="$TEST_NAME" \
-  -Dmondrian.foodmart.jdbcURL="$URL" \
-  -Dmondrian.foodmart.jdbcUser="$USER" \
-  -Dmondrian.foodmart.jdbcPassword="$PASS" \
-  -Dmondrian.jdbcDrivers="$DRIVERS" \
-  "$@"
-"""
+[tasks.java_test]
+description = "Run Java tests, optionally filtered by test class name (e.g., mise java_test NativeFilterMatchingTest)"
+run = "bin/java_test"

--- a/mondrian/pom.xml
+++ b/mondrian/pom.xml
@@ -20,7 +20,7 @@
     <driver.name>Mondrian olap4j driver</driver.name>
     <driver.version.minor>${project.version.minor}</driver.version.minor>
     <driver.version.major>${project.version.major}</driver.version.major>
-    <maven-failsafe-plugin.argLine>-Duser.language=en -Duser.country=US</maven-failsafe-plugin.argLine>
+    <maven-surefire-plugin.argLine>-Duser.language=en -Duser.country=US</maven-surefire-plugin.argLine>
   </properties>
   <dependencies>
     <dependency>
@@ -142,9 +142,9 @@
       <version>${jsp-api.version}</version>
     </dependency>
     <dependency>
-      <groupId>junit</groupId>
-      <artifactId>junit</artifactId>
-      <version>${junit.version}</version>
+      <groupId>org.junit.vintage</groupId>
+      <artifactId>junit-vintage-engine</artifactId>
+      <version>${junit-vintage-engine.version}</version>
       <scope>test</scope>
     </dependency>
     <dependency>
@@ -173,6 +173,12 @@
       <groupId>mysql</groupId>
       <artifactId>mysql-connector-java</artifactId>
       <version>${mysql-connector-java.version}</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.postgresql</groupId>
+      <artifactId>postgresql</artifactId>
+      <version>${postgresql.version}</version>
       <scope>test</scope>
     </dependency>
   </dependencies>
@@ -328,30 +334,22 @@
         <artifactId>maven-surefire-plugin</artifactId>
         <version>${maven-surefire-plugin.version}</version>
         <configuration>
-          <skipTests>true</skipTests>
-        </configuration>
-      </plugin>
-      <plugin>
-        <artifactId>maven-failsafe-plugin</artifactId>
-        <version>${maven-failsafe-plugin.version}</version>
-        <executions>
-          <execution>
-            <id>integration-test</id>
-            <goals>
-              <goal>integration-test</goal>
-            </goals>
-          </execution>
-        </executions>
-
-        <configuration>
           <includes>
-            <include>Main.java</include>
+            <include>**/Main.java</include>
           </includes>
+          <argLine>${maven-surefire-plugin.argLine}</argLine>
           <systemPropertyVariables>
             <mondrian.foodmart.jdbcURL>${mondrian.foodmart.jdbcURL}</mondrian.foodmart.jdbcURL>
             <mondrian.foodmart.jdbcUser>${mondrian.foodmart.jdbcUser}</mondrian.foodmart.jdbcUser>
             <mondrian.foodmart.jdbcPassword>${mondrian.foodmart.jdbcPassword}</mondrian.foodmart.jdbcPassword>
           </systemPropertyVariables>
+        </configuration>
+      </plugin>
+      <plugin>
+        <artifactId>maven-failsafe-plugin</artifactId>
+        <version>${maven-failsafe-plugin.version}</version>
+        <configuration>
+          <skipTests>true</skipTests>
         </configuration>
       </plugin>
     </plugins>
@@ -406,7 +404,7 @@
             <executions>
               <execution>
                 <id>start</id>
-                <phase>pre-integration-test</phase>
+                <phase>process-test-classes</phase>
                 <goals>
                   <goal>stop</goal>
                   <goal>start</goal>
@@ -414,7 +412,7 @@
               </execution>
               <execution>
                 <id>stop</id>
-                <phase>post-integration-test</phase>
+                <phase>prepare-package</phase>
                 <goals>
                   <goal>stop</goal>
                   <goal>remove</goal>
@@ -475,7 +473,7 @@
             <executions>
               <execution>
                 <id>create-foodmart</id>
-                <phase>pre-integration-test</phase>
+                <phase>process-test-classes</phase>
                 <goals>
                   <goal>execute</goal>
                 </goals>
@@ -494,7 +492,7 @@
               </execution>
               <execution>
                 <id>create-steelwheels</id>
-                <phase>pre-integration-test</phase>
+                <phase>process-test-classes</phase>
                 <goals>
                   <goal>execute</goal>
                 </goals>
@@ -558,7 +556,7 @@
             <version>1.5.0</version>
             <executions>
               <execution>
-                <phase>pre-integration-test</phase>
+                <phase>process-test-classes</phase>
                 <goals>
                   <goal>java</goal>
                 </goals>

--- a/mondrian/pom.xml
+++ b/mondrian/pom.xml
@@ -334,6 +334,7 @@
         <artifactId>maven-surefire-plugin</artifactId>
         <version>${maven-surefire-plugin.version}</version>
         <configuration>
+          <redirectTestOutputToFile>true</redirectTestOutputToFile>
           <includes>
             <include>**/Main.java</include>
           </includes>

--- a/mondrian/src/it/java/mondrian/test/MondrianTestRunner.java
+++ b/mondrian/src/it/java/mondrian/test/MondrianTestRunner.java
@@ -18,7 +18,7 @@ package mondrian.test;
 
 import junit.framework.Test;
 import junit.framework.TestResult;
-import junit.runner.*;
+import junit.runner.BaseTestRunner;
 
 import java.io.PrintStream;
 import java.util.Timer;
@@ -55,14 +55,6 @@ public class MondrianTestRunner extends BaseTestRunner {
      */
     public MondrianTestRunner(MondrianResultPrinter printer) {
         fPrinter = printer;
-    }
-
-    /**
-     * Always use the StandardTestSuiteLoader. Overridden from
-     * BaseTestRunner.
-     */
-    public TestSuiteLoader getLoader() {
-        return new StandardTestSuiteLoader();
     }
 
     public void testFailed(int status, Test test, Throwable t) {

--- a/pom.xml
+++ b/pom.xml
@@ -29,9 +29,10 @@
     <eigenbase-properties.version>1.1.2</eigenbase-properties.version>
     <commons-io.version>2.18.0</commons-io.version>
     <mysql-connector-java.version>8.0.27</mysql-connector-java.version>
+    <postgresql.version>42.7.5</postgresql.version>
     <olap4j-tck.version>1.0.1.539</olap4j-tck.version>
     <eigenbase-resgen.version>1.3.1</eigenbase-resgen.version>
-    <junit.version>3.8.1</junit.version>
+    <junit-vintage-engine.version>5.11.4</junit-vintage-engine.version>
     <commons-pool.version>1.2</commons-pool.version>
     <validation-api.version>1.0.0.GA</validation-api.version>
     <commons-collections.version>3.2.2</commons-collections.version>


### PR DESCRIPTION

 - Update testing framework to something a bit more relevant. Move from junit3 (2002) to junit5 vintage compatibility (2024)
 - A part of that upgrade - a way for running single Java tests. Should help with Java -> Ruby migration where relevant.
 - Update README to match.